### PR TITLE
Py3 compatibility fix to explicitly open file in byte mode

### DIFF
--- a/pyxll_utils/extension_loader.py
+++ b/pyxll_utils/extension_loader.py
@@ -57,6 +57,6 @@ if should_make_ribbon:
     except Exception as e:
         if not e.errno == errno.EEXIST:
             raise
-    with open(ribbon_path, 'w') as f:
+    with open(ribbon_path, 'wb') as f:
         f.write(ribbon_synthesizer.to_bytes())
         logger.info("Wrote extended ribbon to {}".format(ribbon_path))


### PR DESCRIPTION
Without this, the `write` method will fail on Python 3.