### PR TITLE
Release version 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyxll_utils',
-      version='1.0',
+      version='2.0',
       author='PyXLL Ltd, Enthought Inc.',
       packages=find_packages(),
       # Provides a namespace for extension points to contribute to. This


### PR DESCRIPTION
This PR simply bumps the version to prepare for a new release of `pyxll-utils`. 

The major version bump is needed because the new feature to contribute ribbon fragments (contributed in #7) is backwards incompatible.